### PR TITLE
Added ability to use app as TA on forwarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,25 @@ This builds a tarball named `mhn-splunk.tar.gz`.
 
 ## Installation
 
+### On Splunk Search Head
+
 1. Open Splunk
 2. Visit the Apps management page
 3. Click "Install App from file"
 4. Choose the `mhn-splunk.spl` file and check the box next to "Upgrade app. Checking this will overwrite the app if it already exists."
 5. Click the "Upload" button.
+
+### On Splunk Forwarder
+
+If your Splunk Indexer resides on a different server to the one you installed MHN, you will need to install a Splunk Forwarder to send MHN data from the MHN Server > Splunk.
+
+1. Download and unpack the app to `SPLUNK_FORWARDER/etc/apps`
+2. Copy `SPLUNK_FORWARDER/etc/apps/mhn-splunk/default/inputs.conf` to `SPLUNK_FORWARDER/etc/apps/mhn-splunk/local`
+3. Edit `SPLUNK_FORWARDER/etc/apps/mhn-splunk/local/inputs.conf` and change `disabled=true` to `disabled=false`
+4. Configure an `output.conf` file to tell the Splunk Forwarder where to send the data.
+4. Restart Splunk
+
+### Notes: [please ensure you have configured Splunk integration as documented here first](https://github.com/threatstream/mhn).
 
 ## LICENSE
 

--- a/mhn-splunk/default/data/ui/views/README
+++ b/mhn-splunk/default/data/ui/views/README
@@ -1,1 +1,0 @@
-Add all the views that your app needs in this directory

--- a/mhn-splunk/default/data/ui/views/conpot_analytics.xml
+++ b/mhn-splunk/default/data/ui/views/conpot_analytics.xml
@@ -14,7 +14,7 @@
       <chart>
         <title>Conpot Events per Hour</title>
         <search>
-          <query>source="*mhn-splunk.log*" app=conpot | timechart span=1h count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" app=conpot | timechart span=1h count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -47,7 +47,7 @@
       <chart>
         <title>Top Types</title>
         <search>
-          <query>source="*mhn-splunk.log*" app=conpot  | top type</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" app=conpot  | top type</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -83,7 +83,7 @@
       <chart>
         <title>Top Attacker Countries</title>
         <search>
-          <query>source="*mhn-splunk.log*" app=conpot | iplocation src | top Country</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" app=conpot | iplocation src | top Country</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -114,7 +114,7 @@
       <table>
         <title>Top Conpot Attackers</title>
         <search>
-          <query>source="*mhn-splunk.log*" app=conpot | top src | iplocation src | fields src, Country, count | fillnull value=unknown Country | eval DShield="DShield"</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" app=conpot | top src | iplocation src | fields src, Country, count | fillnull value=unknown Country | eval DShield="DShield"</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -159,7 +159,7 @@
       <table>
         <title>Top Conpot Sensors</title>
         <search>
-          <query>source="*mhn-splunk.log*" app=conpot | top sensor | fields sensor, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" app=conpot | top sensor | fields sensor, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -176,7 +176,7 @@
       <event>
         <title>Copot Events</title>
         <search>
-          <query>source="*mhn-splunk.log*" app=conpot</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" app=conpot</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>

--- a/mhn-splunk/default/data/ui/views/dionaea_analytics.xml
+++ b/mhn-splunk/default/data/ui/views/dionaea_analytics.xml
@@ -14,7 +14,7 @@
       <chart>
         <title>Dionaea Events per Hour</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=dionaea.connections | timechart span=1h count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=dionaea.connections | timechart span=1h count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -47,7 +47,7 @@
       <table>
         <title>Top MD5s Captured</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=dionaea.capture md5=* | top md5 | fields md5, count | eval VirusTotal="VirusTotal" | eval TotalHash="TotalHash"</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=dionaea.capture md5=* | top md5 | fields md5, count | eval VirusTotal="VirusTotal" | eval TotalHash="TotalHash"</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -78,7 +78,7 @@
       <table>
         <title>Top URLs Captured</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=dionaea.capture url=* | top url | fields url, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=dionaea.capture url=* | top url | fields url, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -95,7 +95,7 @@
       <table>
         <title>Top Dionaea Attackers</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=dionaea.connections | top src |  iplocation src | fields src, Country, count | fillnull value=Unknown Country | eval DShield="DShield"</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=dionaea.connections | top src |  iplocation src | fields src, Country, count | fillnull value=Unknown Country | eval DShield="DShield"</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -140,7 +140,7 @@
       <table>
         <title>Top Ports</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=dionaea.connections | top dest_port | fields dest_port, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=dionaea.connections | top dest_port | fields dest_port, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -155,7 +155,7 @@
       <table>
         <title>Top Sensors</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=dionaea.connections | top sensor | fields sensor, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=dionaea.connections | top sensor | fields sensor, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -172,7 +172,7 @@
       <event>
         <title>Dionaea Events</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=dionaea.connections</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=dionaea.connections</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>

--- a/mhn-splunk/default/data/ui/views/elastichoney_analytics.xml
+++ b/mhn-splunk/default/data/ui/views/elastichoney_analytics.xml
@@ -14,7 +14,7 @@
       <chart>
         <title>Events Per Hour</title>
         <search>
-          <query>source="*mhn-splunk.log*" type="elastichoney.events" | timechart span=1h count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type="elastichoney.events" | timechart span=1h count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -47,7 +47,7 @@
       <map>
         <title>Global Attacks</title>
         <search>
-          <query>source="*mhn-splunk.log*" type="elastichoney.events" | iplocation src | geostats count by src globallimit=20</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type="elastichoney.events" | iplocation src | geostats count by src globallimit=20</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -69,7 +69,7 @@
       <chart>
         <title>Top Attacker Countries</title>
         <search>
-          <query>source="*mhn-splunk.log*" type="elastichoney.events" | iplocation src | top Country</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type="elastichoney.events" | iplocation src | top Country</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -103,7 +103,7 @@
       <chart>
         <title>Top Signatures</title>
         <search>
-          <query>source="*mhn-splunk.log*" type="elastichoney.events" |  top signature | fields signature, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type="elastichoney.events" |  top signature | fields signature, count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -138,7 +138,7 @@
       <chart>
         <title>Top Attacker Cities</title>
         <search>
-          <query>source="*mhn-splunk.log*" type="elastichoney.events" | iplocation src | where City!="" | top City</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type="elastichoney.events" | iplocation src | where City!="" | top City</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -176,7 +176,7 @@
       <table>
         <title>Top Attackers</title>
         <search>
-          <query>source="*mhn-splunk.log*" type="elastichoney.events" | rename event.* as * | rex field=src mode=sed s/::ffff:// | chart sparkline as Sparkline, count by src | rename src as Source | sort 10 -count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type="elastichoney.events" | rename event.* as * | rex field=src mode=sed s/::ffff:// | chart sparkline as Sparkline, count by src | rename src as Source | sort 10 -count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -200,7 +200,7 @@
       <table>
         <title>Top Attack Payloads</title>
         <search>
-          <query>source="*mhn-splunk.log*" type="elastichoney.events" | rex field=_raw "getRuntime\(\)\.exec\((?&lt;command&gt;.[^\)]+)" | eval decoded=urldecode(command) | top decoded | fields decoded,count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type="elastichoney.events" | rex field=_raw "getRuntime\(\)\.exec\((?&lt;command&gt;.[^\)]+)" | eval decoded=urldecode(command) | top decoded | fields decoded,count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -215,7 +215,7 @@
       <table>
         <title>Top Sensors</title>
         <search>
-          <query>source="*mhn-splunk.log*" type="elastichoney.events" | top sensor, app | fields sensor, app, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type="elastichoney.events" | top sensor, app | fields sensor, app, count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>

--- a/mhn-splunk/default/data/ui/views/indicators.xml
+++ b/mhn-splunk/default/data/ui/views/indicators.xml
@@ -14,7 +14,7 @@
       <table>
         <title>Top MD5s Captured</title>
         <search>
-          <query>source="*mhn-splunk.log*" md5=* | top md5 limit=50 | fields md5, count | eval VirusTotal="VirusTotal" | eval TotalHash="TotalHash"</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" md5=* | top md5 limit=50 | fields md5, count | eval VirusTotal="VirusTotal" | eval TotalHash="TotalHash"</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -45,7 +45,7 @@
       <table>
         <title>Top URLs Captured</title>
         <search>
-          <query>source="*mhn-splunk.log*" (type=dionaea.capture OR type=kippo.sessions) url=* | top url limit=50 | fields url, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" (type=dionaea.capture OR type=kippo.sessions) url=* | top url limit=50 | fields url, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -60,7 +60,7 @@
       <table>
         <title>Top Attackers</title>
         <search>
-          <query>source="*mhn-splunk.log*"  | top src limit=50 |  iplocation src | fields src, Country, count | fillnull value=Unknown Country | eval DShield="DShield"</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*"  | top src limit=50 |  iplocation src | fields src, Country, count | fillnull value=Unknown Country | eval DShield="DShield"</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>

--- a/mhn-splunk/default/data/ui/views/kippo_analytics.xml
+++ b/mhn-splunk/default/data/ui/views/kippo_analytics.xml
@@ -14,7 +14,7 @@
       <chart>
         <title>Kippo Events per Hour</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=kippo.sessions | timechart span=1h count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=kippo.sessions | timechart span=1h count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -47,7 +47,7 @@
       <table>
         <title>Top Usernames</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=kippo.sessions ssh_username=* | top ssh_username | fields ssh_username, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=kippo.sessions ssh_username=* | top ssh_username | fields ssh_username, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -62,7 +62,7 @@
       <table>
         <title>Top Passwords</title>
         <search>
-          <query>source="*mhn-splunk.log*" ssh_password=* |  top ssh_password | fields ssh_password, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" ssh_password=* |  top ssh_password | fields ssh_password, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -77,7 +77,7 @@
       <table>
         <title>Top Username/Password Combinations</title>
         <search>
-          <query>source="*mhn-splunk.log*" ssh_username=* ssh_password=* | top ssh_username, ssh_password | fields ssh_username, ssh_password, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" ssh_username=* ssh_password=* | top ssh_username, ssh_password | fields ssh_username, ssh_password, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -94,7 +94,7 @@
       <table>
         <title>Top URLs Downloaded</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=kippo.sessions url=* | top url | fields url, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=kippo.sessions url=* | top url | fields url, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -109,7 +109,7 @@
       <table>
         <title>Top Commands Executed</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=kippo.sessions command=* | top command | fields command, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=kippo.sessions command=* | top command | fields command, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -126,7 +126,7 @@
       <table>
         <title>Top Kippo Attackers</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=kippo.sessions | top src | iplocation src | fields src, Country, count | fillnull value=unknown Country | eval DShield="DShield"</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=kippo.sessions | top src | iplocation src | fields src, Country, count | fillnull value=unknown Country | eval DShield="DShield"</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -171,7 +171,7 @@
       <table>
         <title>Top SSH Versions</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=kippo.sessions | top ssh_version | fields ssh_version, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=kippo.sessions | top ssh_version | fields ssh_version, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -186,7 +186,7 @@
       <table>
         <title>Top Sensors</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=kippo.sessions | top sensor | fields sensor, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=kippo.sessions | top sensor | fields sensor, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -203,7 +203,7 @@
       <event>
         <title>Kippo Events</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=kippo.sessions</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=kippo.sessions</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>

--- a/mhn-splunk/default/data/ui/views/overview.xml
+++ b/mhn-splunk/default/data/ui/views/overview.xml
@@ -14,7 +14,7 @@
       <single>
         <title>Attacks</title>
         <search>
-          <query>source="*mhn-splunk.log*" | timechart span=24h count | reverse</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" | timechart span=24h count | reverse</query>
           <earliest></earliest>
           <latest></latest>
         </search>
@@ -36,7 +36,7 @@
       <single>
         <title>Unique Attacks</title>
         <search>
-          <query>source="*mhn-splunk.log*" |timechart distinct_count(src) as count span=24h | reverse</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" |timechart distinct_count(src) as count span=24h | reverse</query>
           <earliest></earliest>
           <latest></latest>
         </search>
@@ -58,7 +58,7 @@
       <single>
         <title>Unique MD5s</title>
         <search>
-          <query>source="*mhn-splunk.log*" md5=* |timechart distinct_count(md5) as count span=24h | reverse</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" md5=* |timechart distinct_count(md5) as count span=24h | reverse</query>
           <earliest></earliest>
           <latest></latest>
         </search>
@@ -80,7 +80,7 @@
       <single>
         <title>Unique URLs</title>
         <search>
-          <query>source="*mhn-splunk.log*" url=* |timechart distinct_count(url) as count span=24h | reverse</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" url=* |timechart distinct_count(url) as count span=24h | reverse</query>
           <earliest></earliest>
           <latest></latest>
         </search>
@@ -102,7 +102,7 @@
       <single>
         <title>Commands Executed</title>
         <search>
-          <query>source="*mhn-splunk.log*" command=* app=kippo | timechart span=24h count | reverse</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" command=* app=kippo | timechart span=24h count | reverse</query>
           <earliest></earliest>
           <latest></latest>
         </search>
@@ -127,7 +127,7 @@
     <panel>
       <chart>
         <search>
-          <query>source="*mhn-splunk.log*" | timechart span=1h count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" | timechart span=1h count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -160,7 +160,7 @@
       <map>
         <title>Global Attacks</title>
         <search>
-          <query>source="*mhn-splunk.log*" | iplocation src | geostats count by src globallimit=20</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" | iplocation src | geostats count by src globallimit=20</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -182,7 +182,7 @@
       <chart>
         <title>Top Attacker Countries</title>
         <search>
-          <query>source="*mhn-splunk.log*" | iplocation src | top Country</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" | iplocation src | top Country</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -216,7 +216,7 @@
       <chart>
         <title>Top Attacker Cities</title>
         <search>
-          <query>source="*mhn-splunk.log*" | iplocation src | where City!="" | top City</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" | iplocation src | where City!="" | top City</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -252,7 +252,7 @@
       <chart>
         <title>Top Honeypots by type</title>
         <search>
-          <query>source="*mhn-splunk.log*" | top type</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" | top type</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -288,7 +288,7 @@
       <chart>
         <title>Top Ports</title>
         <search>
-          <query>source="*mhn-splunk.log*" | top dest_port | fields dest_port, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" | top dest_port | fields dest_port, count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -326,7 +326,7 @@
       <table>
         <title>Top Attackers</title>
         <search>
-          <query>source="*mhn-splunk.log*" | rename event.* as * | rex field=src mode=sed s/::ffff:// | chart sparkline as Sparkline, count by src | rename src as Source | sort 10 -count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" | rename event.* as * | rex field=src mode=sed s/::ffff:// | chart sparkline as Sparkline, count by src | rename src as Source | sort 10 -count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -350,7 +350,7 @@
       <table>
         <title>Top Attacker OSes</title>
         <search>
-          <query>source="*mhn-splunk.log*" p0f_os=* | where p0f_os!="???" |  top p0f_os | fields p0f_os, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" p0f_os=* | where p0f_os!="???" |  top p0f_os | fields p0f_os, count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -363,7 +363,7 @@
       <table>
         <title>Top Usernames</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=kippo.sessions ssh_username=* | top ssh_username | fields ssh_username, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=kippo.sessions ssh_username=* | top ssh_username | fields ssh_username, count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -399,7 +399,7 @@
       <table>
         <title>Top Passwords</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=kippo.sessions ssh_password=* | top ssh_password | fields ssh_password, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=kippo.sessions ssh_password=* | top ssh_password | fields ssh_password, count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -416,7 +416,7 @@
       <table>
         <title>Top Sensors</title>
         <search>
-          <query>source="*mhn-splunk.log*" | top sensor, app | fields sensor, app, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" | top sensor, app | fields sensor, app, count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -452,7 +452,7 @@
       <table>
         <title>Top Md5's</title>
         <search>
-          <query>source="*mhn-splunk.log*" AND md5 != None | top md5 | fields md5, count | eval VirusTotal="VirusTotal" | eval TotalHash="TotalHash"</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" AND md5 != None | top md5 | fields md5, count | eval VirusTotal="VirusTotal" | eval TotalHash="TotalHash"</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -483,7 +483,7 @@
       <table>
         <title>Top URLs</title>
         <search>
-          <query>source="*mhn-splunk.log*" url=* |  top url, app | fields url, app, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" url=* |  top url, app | fields url, app, count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -498,7 +498,7 @@
       <table>
         <title>Top Signatures</title>
         <search>
-          <query>source="*mhn-splunk.log*" |  top signature | fields signature, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" |  top signature | fields signature, count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>

--- a/mhn-splunk/default/data/ui/views/p0f_analytics.xml
+++ b/mhn-splunk/default/data/ui/views/p0f_analytics.xml
@@ -14,7 +14,7 @@
       <chart>
         <title>p0f Events per Hour</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=p0f.events | timechart span=1h count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=p0f.events | timechart span=1h count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -47,7 +47,7 @@
       <table>
         <title>Top p0f OSes</title>
         <search>
-          <query>source="*mhn-splunk.log*" p0f_os=* | where p0f_os!="???" |  top p0f_os | fields p0f_os, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" p0f_os=* | where p0f_os!="???" |  top p0f_os | fields p0f_os, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -62,7 +62,7 @@
       <table>
         <title>Top p0f Apps</title>
         <search>
-          <query>source="*mhn-splunk.log*" p0f_app=* | where p0f_app!="???" |  top p0f_app | fields p0f_app, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" p0f_app=* | where p0f_app!="???" |  top p0f_app | fields p0f_app, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -77,7 +77,7 @@
       <table>
         <title>Top p0f Links</title>
         <search>
-          <query>source="*mhn-splunk.log*" p0f_link=* | where p0f_link!="???" | top p0f_link | fields p0f_link, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" p0f_link=* | where p0f_link!="???" | top p0f_link | fields p0f_link, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -94,7 +94,7 @@
       <table>
         <title>Top p0f Attackers</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=p0f.events | top src | fields src, count | iplocation src | fields src, Country, count | fillnull value=unknown Country | eval DShield="DShield"</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=p0f.events | top src | fields src, count | iplocation src | fields src, Country, count | fillnull value=unknown Country | eval DShield="DShield"</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -139,7 +139,7 @@
       <table>
         <title>Top Ports</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=p0f.events | top dest_port | fields dest_port, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=p0f.events | top dest_port | fields dest_port, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -154,7 +154,7 @@
       <table>
         <title>Top Sensors</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=p0f.events | top sensor | fields sensor, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=p0f.events | top sensor | fields sensor, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -171,7 +171,7 @@
       <event>
         <title>p0f Events</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=p0f.events</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=p0f.events</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>

--- a/mhn-splunk/default/data/ui/views/shockpot_analytics.xml
+++ b/mhn-splunk/default/data/ui/views/shockpot_analytics.xml
@@ -14,7 +14,7 @@
       <chart>
         <title>Shockpot Events per Hour</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=shockpot.events | timechart span=1h count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" type=shockpot.events | timechart span=1h count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -47,7 +47,7 @@
       <table>
         <title>Top MD5s</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=shockpot.events md5=* | top md5 | fields md5, count | eval VirusTotal="VirusTotal" | eval TotalHash="TotalHash"</query>
+          <query>index=mhn sourcetype= source="*mhn-splunk.log*" type=shockpot.events md5=* | top md5 | fields md5, count | eval VirusTotal="VirusTotal" | eval TotalHash="TotalHash"</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -78,7 +78,7 @@
       <table>
         <title>Top SHA1s</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=shockpot.events sha1=* | top sha1 | fields sha1, count | eval VirusTotal="VirusTotal" | eval TotalHash="TotalHash"</query>
+          <query>index=mhn sourcetype= source="*mhn-splunk.log*" type=shockpot.events sha1=* | top sha1 | fields sha1, count | eval VirusTotal="VirusTotal" | eval TotalHash="TotalHash"</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -109,7 +109,7 @@
       <table>
         <title>Top SHA256s</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=shockpot.events sha256=* | top sha256 | fields sha256, count | eval VirusTotal="VirusTotal" | eval TotalHash="TotalHash"</query>
+          <query>index=mhn sourcetype= source="*mhn-splunk.log*" type=shockpot.events sha256=* | top sha256 | fields sha256, count | eval VirusTotal="VirusTotal" | eval TotalHash="TotalHash"</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -142,7 +142,7 @@
       <table>
         <title>Top Shockpot Attackers</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=shockpot.events | top src | iplocation src | fields src, Country, count | fillnull value=unknown Country | eval DShield="DShield"</query>
+          <query>index=mhn sourcetype= source="*mhn-splunk.log*" type=shockpot.events | top src | iplocation src | fields src, Country, count | fillnull value=unknown Country | eval DShield="DShield"</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -187,7 +187,7 @@
       <table>
         <title>Top URLs Downloaded</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=shockpot.events url=* | top url | fields url, count</query>
+          <query>index=mhn sourcetype= source="*mhn-splunk.log*" type=shockpot.events url=* | top url | fields url, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -202,7 +202,7 @@
       <table>
         <title>Top Sensors</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=shockpot.events | top sensor | fields sensor, count</query>
+          <query>index=mhn sourcetype= source="*mhn-splunk.log*" type=shockpot.events | top sensor | fields sensor, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -219,7 +219,7 @@
       <event>
         <title>Shockpot Events</title>
         <search>
-          <query>source="*mhn-splunk.log*" type=shockpot.events</query>
+          <query>index=mhn sourcetype= source="*mhn-splunk.log*" type=shockpot.events</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>

--- a/mhn-splunk/default/data/ui/views/snortsuricata_analytics.xml
+++ b/mhn-splunk/default/data/ui/views/snortsuricata_analytics.xml
@@ -14,7 +14,7 @@
       <chart>
         <title>Sensor Events per Hour</title>
         <search>
-          <query>source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | timechart span=1h count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | timechart span=1h count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -47,7 +47,7 @@
       <table>
         <title>Top Sources</title>
         <search>
-          <query>source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top src | iplocation src | fields src, Country, count | fillnull value=Unknown Country | eval DShield="DShield"</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top src | iplocation src | fields src, Country, count | fillnull value=Unknown Country | eval DShield="DShield"</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -92,7 +92,7 @@
       <table>
         <title>Top Destinations</title>
         <search>
-          <query>source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top dest | iplocation dest | fields dest, Country, count | fillnull value=Unknown Country</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top dest | iplocation dest | fields dest, Country, count | fillnull value=Unknown Country</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -128,7 +128,7 @@
       <table>
         <title>Top Source Ports</title>
         <search>
-          <query>source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top src_port | fields src_port, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top src_port | fields src_port, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -143,7 +143,7 @@
       <table>
         <title>Top Destination Ports</title>
         <search>
-          <query>source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top dest_port | fields dest_port, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top dest_port | fields dest_port, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -160,7 +160,7 @@
       <table>
         <title>Top Sensors</title>
         <search>
-          <query>source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top sensor, app | fields sensor, app, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top sensor, app | fields sensor, app, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -175,7 +175,7 @@
       <table>
         <title>Top Protocols</title>
         <search>
-          <query>source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top protocol | fields protocol, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top protocol | fields protocol, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -190,7 +190,7 @@
       <table>
         <title>Top Severities</title>
         <search>
-          <query>source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top severity | fields severity, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top severity | fields severity, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -205,7 +205,7 @@
       <table>
         <title>Top Signatures</title>
         <search>
-          <query>source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top signature | fields signature, count</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts) | top signature | fields signature, count</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>
@@ -222,7 +222,7 @@
       <event>
         <title>Snort/Suricata Events</title>
         <search>
-          <query>source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts)</query>
+          <query>index=mhn sourcetype=mhn-splunk-kv source="*mhn-splunk.log*" (type=snort.alerts OR type=suricata.alerts)</query>
           <earliest>$time_range.earliest$</earliest>
           <latest>$time_range.latest$</latest>
         </search>

--- a/mhn-splunk/default/indexes.conf
+++ b/mhn-splunk/default/indexes.conf
@@ -1,0 +1,7 @@
+[mhn]
+coldPath = $SPLUNK_DB/mhn/colddb
+enableDataIntegrityControl = 0
+enableTsidxReduction = 0
+homePath = $SPLUNK_DB/mhn/db
+maxTotalDataSizeMB = 512000
+thawedPath = $SPLUNK_DB/mhn/thaweddb

--- a/mhn-splunk/default/inputs.conf
+++ b/mhn-splunk/default/inputs.conf
@@ -1,0 +1,4 @@
+[monitor:///var/log/mhn/mhn-splunk.log]
+disabled = true
+index = mhn
+sourcetype = mhn-splunk-kv

--- a/mhn-splunk/default/props.conf
+++ b/mhn-splunk/default/props.conf
@@ -1,0 +1,6 @@
+[mhn-splunk-kv]
+DATETIME_CONFIG =
+NO_BINARY_CHECK = true
+category = Custom
+disabled = false
+pulldown_type = true


### PR DESCRIPTION
* added default index “mhn” to avoid issues around setting default indexes, dumping data in default Splunk ended etc.
* added default source type to potentially catch any log format changes in future
* also added new index and source type to search in UI xml view. IMPORTANT: this will break the app for existing users
* above allows app to be used as TA on forwarder to simplify setup for user.
* readme updated to reflect this